### PR TITLE
Fix the table of contents failing to expand on mobile.

### DIFF
--- a/resources/pcgw.js
+++ b/resources/pcgw.js
@@ -31,7 +31,7 @@ function stickyTableOfContents() {
 }
 
 function mobileTableOfContents() {
-	$("#toctitle").click(function() {
+	$(".toctitle").click(function() {
 		$("#toc").toggleClass('active');
 	});
 }


### PR DESCRIPTION
MediaWiki must have changed this at some point, I guess?

Fixes https://trello.com/c/lUq7YCVf/109-menu-not-showing-on-mobile-view