### PR TITLE
Support MediaWiki >= 1.35

### DIFF
--- a/Overclocked.skin.php
+++ b/Overclocked.skin.php
@@ -60,16 +60,6 @@ class SkinOverclocked extends SkinTemplate {
 		    $out->addHeadItem('pcgw-admanager', '<script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" data-site-id="5ee882ebb519801b8a4d573b" data-mode="scan" async></script>');
 		}
 		$out->addModules( array( 'skins.overclocked.js' ) );
-	}
-
-	/**
-	 * Add CSS via ResourceLoader
-	 *
-	 * @param $out OutputPage
-	 */
-	function setupSkinUserCss( OutputPage $out ) {
-		parent::setupSkinUserCss( $out );
-
 		$out->addModuleStyles( array(
 			'mediawiki.skinning.elements', 'skins.overclocked.styles'
 		) );
@@ -188,7 +178,7 @@ class OverclockedTemplate extends BaseTemplate {
 
 						foreach($sidebar as $boxName => $box) {
 							?>
-							<li   id='<?php echo Sanitizer::escapeId( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
+							<li   id='<?php echo Sanitizer::escapeIdForAttribute( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
 								<span class="header-item dropdown-toggle"><?php echo htmlspecialchars( $box['header'] ); ?></span>
 								<?php
 									if(is_array($box['content'])) { ?>

--- a/skin.json
+++ b/skin.json
@@ -1,0 +1,69 @@
+{
+	"name": "Overclocked",
+	"version": "1.0",
+	"author": [
+		"PCGamingWiki Team"
+	],
+	"url": "https://github.com/PCGamingWiki/overclocked",
+	"descriptionmsg": "overclocked-desc",
+	"namemsg": "skinname-overclocked",
+	"license-name": "GPL-2.0+",
+	"type": "skin",
+	"manifest_version": 2,
+	"ValidSkinNames": {
+		"overclocked": {
+			"class": "SkinOverclocked",
+			"args": [
+				{
+					"name": "overclocked"
+				}
+			]
+		}
+	},
+	"MessagesDirs": {
+		"ModernSkylight": [
+			"i18n"
+		]
+	},
+	"AutoloadClasses": {
+		"SkinOverclocked": "Overclocked.skin.php"
+	},
+	"ResourceModules": {
+		"skins.overclocked.styles": {
+			"styles": [
+				"resources/general-header.less",
+				"resources/general-footer.less",
+				"resources/general-personalbar.less",
+				"resources/general-toc.less",
+				"resources/general-inputfields.less",
+				"resources/general-specialpages.less",
+				"resources/pcgw.less",
+				"resources/pcgw-templates.less",
+				"resources/pcgw-icons.less",
+				"resources/mediawiki.custom.less",
+				"resources/mediawiki.mediaviewer.overrides.less",
+				"resources/page-home.less",
+				"resources/page-extension.less",
+				"resources/page-donate.less",
+				"resources/page-editing-guide.less",
+				"resources/other.less"
+			]
+		},
+		"skins.overclocked.js": {
+			"scripts": [
+				"resources/jquery/jquery.waypoints.min.js",
+				"resources/jquery/jquery.ba-outside-events.min.js",
+				"resources/pcgw.js"
+			]
+		}
+	},
+	"ResourceModuleSkinStyles": {
+		"mediawiki.special.preferences": [
+			"resources/mediawiki.special.preferences.less"
+		]
+	},
+	"ResourceFileModulePaths": {
+		"localBasePath": "",
+		"remoteSkinPath": "Overclocked"
+	}
+}


### PR DESCRIPTION
I would like to showcase this skin on https://skins.wmflabs.org/ and update the skins status on https://www.mediawiki.org/wiki/Skin:Overclocked to stable.

The skin requires extension registration via wfLoadSkin in
1.35 and the method setupSkinUserCss is deprecated.

This change should have no effect on older versions of MediaWiki.
