### PR TITLE
Re-instating editing, history and page-moving on phones

### DIFF
--- a/resources/mediawiki.custom.less
+++ b/resources/mediawiki.custom.less
@@ -662,10 +662,7 @@ ol.references {
 	/* Hide all of mw-head-right except for the watch star. */
 	#mw-head-right {
 		#ca-view,
-		#ca-edit,
-		#ca-history,
-		#ca-viewsource,
-		#mw-head-more {
+		#ca-viewsource {
 			display: none;
 		}
 	}


### PR DESCRIPTION
As simple as that.

Because unless there's some old major glitches I'm unaware of, page-editing and looking at a page's history without switching to «Firefox for Android»'s very clunky desktop view mode, is very crucial. Like, if I'm sitting on a bus or interregional train, or if I'm testing stuff on someone else's Mac while 35min away from home.