### PR TITLE
Fix compatibility with MediaWiki 1.43

### DIFF
--- a/Overclocked.php
+++ b/Overclocked.php
@@ -59,6 +59,13 @@ $GLOBALS['wgDefaultUserOptions']['overclocked-ads'] = 0;
 $GLOBALS['wgDefaultUserOptions']['overclocked-floating-toc'] = 0;
 
 $GLOBALS['wgResourceModules']['skins.overclocked.styles'] = array(
+	// 1.43: SkinModule provides base content styles via features (plain file module gave none)
+	'class' => 'MediaWiki\\ResourceLoader\\SkinModule',
+	'features' => array(
+		'normalize', 'elements', 'content-media', 'content-links',
+		'content-tables', 'interface', 'interface-category',
+		'i18n-ordered-lists', 'i18n-headings',
+	),
 	'styles' => array(
 		'resources/general-header.less',
 		'resources/general-footer.less',

--- a/Overclocked.skin.php
+++ b/Overclocked.skin.php
@@ -39,12 +39,14 @@ class SkinOverclocked extends SkinTemplate {
 		/* Theme meta tag for "brand" coloring in certain browsers.
 		   Off-black to match the fixed header. */
 		$out->addMeta( 'theme-color', '#333' );
-		if( !$out->getUser()->isLoggedIn() ) {
+		if( !$out->getUser()->isRegistered() ) {  // 1.43: was isLoggedIn
 		    $toggleGoogleAds = true;
 		}
 		else {
 		    $user = $out->getUser();
-		    $toggleGoogleAds = $user->getOption( 'overclocked-ads' );
+		    // 1.43: was getOption
+		    $toggleGoogleAds = MediaWiki\MediaWikiServices::getInstance()
+		        ->getUserOptionsLookup()->getOption( $user, 'overclocked-ads' );
 		}
 
 		/**
@@ -60,19 +62,8 @@ class SkinOverclocked extends SkinTemplate {
 		    $out->addHeadItem('pcgw-admanager', '<script src="https://hb.vntsm.com/v3/live/ad-manager.min.js" type="text/javascript" data-site-id="5ee882ebb519801b8a4d573b" data-mode="scan" async></script>');
 		}
 		$out->addModules( array( 'skins.overclocked.js' ) );
-	}
-
-	/**
-	 * Add CSS via ResourceLoader
-	 *
-	 * @param $out OutputPage
-	 */
-	function setupSkinUserCss( OutputPage $out ) {
-		parent::setupSkinUserCss( $out );
-
-		$out->addModuleStyles( array(
-			'mediawiki.skinning.elements', 'skins.overclocked.styles'
-		) );
+		// 1.43: was setupSkinUserCss; base styles now come from the SkinModule
+		$out->addModuleStyles( array( 'skins.overclocked.styles' ) );
 	}
 }
 
@@ -129,7 +120,9 @@ class OverclockedTemplate extends BaseTemplate {
 			/**
 			 * Replace watch button with star
 			 */
-			$watchStatus = $this->getSkin()->getUser()->isWatched( $this->getSkin()->getRelevantTitle() ) ? 'unwatch' : 'watch';
+			// 1.43: was isWatched
+			$watchStatus = MediaWiki\MediaWikiServices::getInstance()->getWatchlistManager()
+				->isWatched( $this->getSkin()->getUser(), $this->getSkin()->getRelevantTitle() ) ? 'unwatch' : 'watch';
 
 			if ( isset( $pageNav['actions'][$watchStatus] ) ) {
 				$pageNav['views'][$watchStatus] = $pageNav['actions'][$watchStatus];
@@ -142,8 +135,10 @@ class OverclockedTemplate extends BaseTemplate {
 			 * Preferences
 			 */
 			$user = $this->getSkin()->getUser();
-			$toggleGoogleAds = $user->getOption( 'overclocked-ads' );
-			$toggleFloatingTOC = $user->getOption( 'overclocked-floating-toc' );
+			// 1.43: was getOption
+			$userOptionsLookup = MediaWiki\MediaWikiServices::getInstance()->getUserOptionsLookup();
+			$toggleGoogleAds = $userOptionsLookup->getOption( $user, 'overclocked-ads' );
+			$toggleFloatingTOC = $userOptionsLookup->getOption( $user, 'overclocked-floating-toc' );
 		}
 
 		global $wgSkinOverclockedAds;
@@ -198,7 +193,7 @@ class OverclockedTemplate extends BaseTemplate {
 
 						foreach($sidebar as $boxName => $box) {
 							?>
-							<li   id='<?php echo Sanitizer::escapeId( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
+							<li   id='<?php echo Sanitizer::escapeIdForAttribute( $box['id'] ) ?>'<?php echo Linker::tooltip( $box['id'] ) ?>>
 								<span class="header-item dropdown-toggle"><?php echo htmlspecialchars( $box['header'] ); ?></span>
 								<?php
 									if(is_array($box['content'])) { ?>
@@ -492,12 +487,11 @@ class OverclockedTemplate extends BaseTemplate {
 
 			<!-- Page last modified, copyright, and disclaimer texts -->
 			<?php
-			if ( isset( $this->getFooterLinks()['info'] ) ) {
-				$footerNav = $this->getFooterLinks()['info'] ?>
-				<div id="footer-info-lastmod"><?php $this->html( $footerNav[0] ) ?></div>
-				<div id="footer-info-copyright"><?php $this->html( $footerNav[1] ) ?></div>
-			<?php
-			}
+			// 1.43: getFooterLinks()['info'] is a list of key names
+			$footerInfo = $this->getFooterLinks()['info'] ?? [];
+			foreach ( $footerInfo as $footerKey ) { ?>
+				<div id="footer-info-<?php echo $footerKey ?>"><?php $this->html( $footerKey ) ?></div>
+			<?php }
 			?>
 			<div id="footer-info-disclaimer">Some store links may include affiliate tags. Buying through these links helps support PCGamingWiki (<a href="/wiki/PCGamingWiki:About#Support_us">Learn more</a>).</div>
 		</div>
@@ -520,7 +514,11 @@ class OverclockedTemplate extends BaseTemplate {
 <!-- Open Sans font family -->
 <link rel="stylesheet" media="screen" href="//fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,400,300,600">
 
-<?php $this->printTrail(); ?>
+<?php
+// 1.43: printTrail() removed
+echo $this->get( 'bottomscripts' );
+echo $this->get( 'reporttime' );
+?>
 
 <!-- GOG Affiliate Link Tag -->
 <script type="text/javascript" src="https://cdn.adt598.com/atag.js?as=1649876489" charset="UTF-8"></script>

--- a/resources/general-footer.less
+++ b/resources/general-footer.less
@@ -2,7 +2,7 @@
 @import "mediawiki.mixins";
 
 .background-icon(@name) {
-	.background-image("icons/@{name}.svg");
+	background-image: url("icons/@{name}.svg");
 }
 
 /* ==============================================

--- a/resources/general-header.less
+++ b/resources/general-header.less
@@ -2,7 +2,7 @@
 @import "mediawiki.mixins";
 
 .background-icon(@name) {
-	.background-image("icons/@{name}.svg");
+	background-image: url("icons/@{name}.svg");
 }
 
 /******

--- a/resources/general-personalbar.less
+++ b/resources/general-personalbar.less
@@ -2,10 +2,10 @@
 @import "variables.less";
 
 .background-icon(@name) {
-	.background-image("images/@{name}.svg");
+	background-image: url("images/@{name}.svg");
 
 	&:hover {
-		.background-image('images/@{name}Hover.svg');
+		background-image: url('images/@{name}Hover.svg');
 	}
 }
  
@@ -55,7 +55,7 @@
 		margin-top: 6px;
 		opacity: 0.8;
 
-		.transition(background-color 200ms 100ms, opacity 200ms 100ms;);
+		transition: background-color 200ms 100ms, opacity 200ms 100ms;
 
 		@media all and (min-width: 800px) {
 			&:hover {
@@ -64,7 +64,7 @@
 
 				div > a {
 					background-position: left;
-					.background-image("images/userHover.svg");
+					background-image: url("images/userHover.svg");
 				}
 			}
 		}
@@ -73,7 +73,7 @@
 	#personal-bar-flyout > div {
 		padding: 0 .2rem;
 
-		.transition(border-color 200ms 100ms;);
+		transition: border-color 200ms 100ms;
 
 		a {
 			display: block;
@@ -128,10 +128,10 @@
 		@media all and (min-width: 800px) {
 			background: right 10px top 5px no-repeat;
 			background-size: auto 12px;
-			.background-image("images/carat1.svg");
+			background-image: url("images/carat1.svg");
 
 			&:hover {
-				.background-image("images/caratHover.svg");
+				background-image: url("images/caratHover.svg");
 			}
 
 			border: 1px solid #ccc;
@@ -145,7 +145,7 @@
 				overflow: hidden;
 				width: auto;
 
-				.transition(max-height 0s 100ms, opacity 200ms 100ms;);
+				transition: max-height 0s 100ms, opacity 200ms 100ms;
 			}
 
 			&:hover ul {
@@ -161,7 +161,7 @@
 				color: #fff;
 				padding: 6px 24px;
 
-				.transition(color 200ms 100ms;);
+				transition: color 200ms 100ms;
 			}
 
 			li a:hover {
@@ -233,19 +233,19 @@ li#pt-notifications-notice  {
 }
 
 #pt-watchlist a {
-	.background-image("images/watchlist.svg");
+	background-image: url("images/watchlist.svg");
 }
  
 #pt-mytalk a {
-	.background-image("images/talk.svg");
+	background-image: url("images/talk.svg");
 }
  
 #personal-bar-flyout div > a {
 	font-size: 1.2rem;
 	background-position: left;
-	.background-image("images/user.svg");
+	background-image: url("images/user.svg");
 
-	.transition(background-image 200ms 100ms;);
+	transition: background-image 200ms 100ms;
 }
  
 #pt-mycontris-flyout a {

--- a/resources/general-toc.less
+++ b/resources/general-toc.less
@@ -2,7 +2,7 @@
 @import "variables.less";
 
 .background-icon(@name) {
-	.background-image("images/@{name}.svg");
+	background-image: url("images/@{name}.svg");
 }
 
 // Default MediaWiki styling for the Table of Contents.

--- a/resources/mediawiki.custom.less
+++ b/resources/mediawiki.custom.less
@@ -2,7 +2,7 @@
 @import "variables.less";
 
 .background-icon(@name) {
-	.background-image("images/@{name}.svg");
+	background-image: url("images/@{name}.svg");
 }
 
 /* ==============================================
@@ -236,7 +236,7 @@ div.tright {
 	padding: 3px 5px 3px 5px;
 	font-weight: 300;
 
-	.transition(background-color 200ms 0);
+	transition: background-color 200ms 0;
 }
 
 #pt-notifications-notice .mw-echo-notifications-badge {
@@ -244,7 +244,7 @@ div.tright {
 	padding: 3px 5px 3px 5px;
 	font-weight: 300;
 
-	.transition(background-color 200ms 0);
+	transition: background-color 200ms 0;
 }
 
 // Fix Echo overlay text sizes.
@@ -598,12 +598,12 @@ ol.references {
 
 		background: right 10px top 8px no-repeat;
 		background-size: auto 12px;
-		.background-image("images/carat2.svg");
+		background-image: url("images/carat2.svg");
 
-		.transition(background-color 200ms 100ms, border-color 200ms 100ms;);
+		transition: background-color 200ms 100ms, border-color 200ms 100ms;
 
 		&:hover {
-			.background-image("images/caratHover.svg");
+			background-image: url("images/caratHover.svg");
 			border-color: #aaa;
 			background-color: #fff;
 		}
@@ -621,7 +621,7 @@ ol.references {
 			display: block;
 			border-top: 1px solid #ededed;
 
-			.transition(max-height 0s 100ms, opacity 200ms 100ms;);
+			transition: max-height 0s 100ms, opacity 200ms 100ms;
 		}
 
 		&:hover ul {

--- a/resources/page-editing-guide.less
+++ b/resources/page-editing-guide.less
@@ -2,7 +2,7 @@
 @import "mediawiki.mixins";
 
 .background-icon(@name) {
-	.background-image("icons/editing-guide-@{name}.svg");
+	background-image: url("icons/editing-guide-@{name}.svg");
 }
 
 // Custom section subheader styling and 

--- a/resources/pcgw-icons.less
+++ b/resources/pcgw-icons.less
@@ -1,7 +1,7 @@
 @import "mediawiki.mixins";
 
 .background-icon(@name) {
-	.background-image("icons/@{name}.svg");
+	background-image: url("icons/@{name}.svg");
 }
 
 


### PR DESCRIPTION
Overclocked.skin.php:
- User::isLoggedIn() -> isRegistered()
- User::getOption() -> UserOptionsLookup service
- User::isWatched() -> WatchlistManager service
- Sanitizer::escapeId() -> escapeIdForAttribute()
- setupSkinUserCss() was removed; move addModuleStyles() into initPage()
- printTrail() was removed; output bottomscripts + reporttime directly
- getFooterLinks()['info'] is now a list of link keys, not [0]/[1]

Overclocked.php:
- skins.overclocked.styles is now a SkinModule with base-style features (normalize, elements, content-media, content-links, content-tables, interface, interface-category, i18n-ordered-lists, i18n-headings) so the content area receives MediaWiki's base skinning styles

resources/*.less:
- Replace the removed core LESS mixins .background-image() and .transition() with standard CSS