### PR TITLE
Remove unnecessary headelement output

### DIFF
--- a/Overclocked.skin.php
+++ b/Overclocked.skin.php
@@ -153,7 +153,7 @@ class OverclockedTemplate extends BaseTemplate {
 			$toggleGoogleAds = false;
 		}
 
-		$this->html( 'headelement' ); ?>
+		?>
 
 	<?php if( $toggleGoogleAds == true ) { ?>
 		<?php echo $wgSkinOverclockedAds['tag']; ?>


### PR DESCRIPTION
`$this->html( 'headelement' )` emits `PHP Warning: Undefined array key "headelement"` on every page view under MediaWiki 1.43.

Core no longer supplies `headelement` in template data — `Skin::outputPageFinal()` calls `OutputPage::headElement()` itself after the template runs (see the `T259955: OutputPage::headElement must be called last` comment in `includes/skins/Skin.php`). The call outputs nothing and only warns.

Verified on a 1.43.9 wiki: rendered output unchanged — one well-formed `<head>`, correct title, no other diff — and the warnings stop.
